### PR TITLE
New RequestError/ResponseException

### DIFF
--- a/src/Exception/RequestError/ResponseException.php
+++ b/src/Exception/RequestError/ResponseException.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @license see LICENSE
+ */
+
+namespace Serps\Exception\RequestError;
+
+use Serps\Core\Http\SearchEngineResponse;
+
+class ResponseException extends RequestErrorException
+{
+
+    /**
+     * @var SearchEngineResponse
+     */
+    protected $response;
+
+    public function __construct(SearchEngineResponse $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return SearchEngineResponse
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}


### PR DESCRIPTION
Throw that if response from SearchEgine is undefined. 

This need for manual analysis by SE response. 

It's necessary for that PR https://github.com/serp-spider/search-engine-google/pull/23
