### PR TITLE
Fix parse of expires from the Set-Cookie HTTP header

### DIFF
--- a/src/Core/Cookie/SetCookieString.php
+++ b/src/Core/Cookie/SetCookieString.php
@@ -63,6 +63,11 @@ abstract class SetCookieString
             }
             $data[$key] = $value;
         }
+
+        if (is_string($data['expires'])) {
+            $data['expires'] = strtotime($data['expires']);
+        }
+
         // Calculate the expires date
         if (!$data['expires'] && $data['max_age']) {
             $data['expires'] = time() + (int) $data['max_age'];

--- a/test/suites/TDD/Core/Cookie/SetCookieStringTest.php
+++ b/test/suites/TDD/Core/Cookie/SetCookieStringTest.php
@@ -17,13 +17,16 @@ class SetCookieStringTest extends \PHPUnit_Framework_TestCase
     public function testParseCookie()
     {
 
-        $cookieString = 'foo=bar; path=/; domain=.foo.com; expires=Tue, 01-Jan-2050 08:00:00 GMT';
+        $expiresTime = time();
+        $cookieString = 'foo=bar; path=/; domain=.foo.com;';
+        $cookieString .=' expires=' . gmdate('D, d M Y H:i:s T', $expiresTime);
+        
         $cookie = SetCookieString::parse($cookieString, 'foo.com', '/bar');
 
         $this->assertEquals('foo', $cookie->getName());
         $this->assertEquals('bar', $cookie->getValue());
 
-        $this->assertEquals('Tue, 01-Jan-2050 08:00:00 GMT', $cookie->getExpires());
+        $this->assertEquals($expiresTime, $cookie->getExpires());
         $this->assertEquals('.foo.com', $cookie->getDomain());
 
 


### PR DESCRIPTION
In Cookie instance the expires must contain a unix timestamp, but if you use SetCookieString::parse() in the expires was a time string in gmt format. This is PR fix that.
