### PR TITLE
Fix QueryParam problem with numeric names

### DIFF
--- a/src/Core/Url/QueryParam.php
+++ b/src/Core/Url/QueryParam.php
@@ -78,7 +78,7 @@ class QueryParam
     {
         $value = $this->getValue();
         if (null === $value || strlen($value) == 0) {
-            return $this->getName();
+            return (string) $this->getName();
         }
         return $this->getName() . '=' . $this->getValue();
     }

--- a/test/suites/TDD/Core/Url/QueryParamTest.php
+++ b/test/suites/TDD/Core/Url/QueryParamTest.php
@@ -69,4 +69,13 @@ class QueryParamTest extends \PHPUnit_Framework_TestCase
         $queryParamRaw = new QueryParam('foo', 'foo bar', true);
         $this->assertEquals($queryParamRaw->generate(), (string)$queryParamRaw);
     }
+
+    /**
+     * https://github.com/serp-spider/core/pull/25
+     */
+    public function testToStringWithNullValueAndNumericName()
+    {
+        $queryParamRaw = new QueryParam(14, null, true);
+        $this->assertEquals('14', (string) $queryParamRaw);
+    }
 }


### PR DESCRIPTION
When url has numeric parameter without a value, __toString throws exception, as it does not return a string. Url example: testUrl.com/?14
