### PR TITLE
add @param innotation for $httpClient variable in the constructor

### DIFF
--- a/src/Core/Browser/Browser.php
+++ b/src/Core/Browser/Browser.php
@@ -32,6 +32,7 @@ class Browser extends AbstractBrowser
     protected $httpClient;
 
     /**
+     * @param HttpClientInterface $httpClient HTTP client.
      * @param string|null $userAgent the user agent string
      * @param string|null $acceptLanguage the accept language header. Default to 'en-US,en;q=0.8'
      * @param CookieJarInterface|null $cookieJar a cookie jar to use for requests


### PR DESCRIPTION
The absence of `@param` innotation may lead to confusion!