### PR TITLE
fix for php 7.4

### DIFF
--- a/src/Core/Dom/DomXpath.php
+++ b/src/Core/Dom/DomXpath.php
@@ -34,7 +34,7 @@ class DomXpath extends BaseDomXpath
 
         // NullDomNode is an addition to SERPS and must be handled differently
         if ($context instanceof NullDomNode) {
-            if ($expr{0} == '/') {
+            if ($expr[0] == '/') {
                 $context = null;
             } else {
                 return new EmptyDomNodeList();

--- a/src/Core/Url/UrlArchiveTrait.php
+++ b/src/Core/Url/UrlArchiveTrait.php
@@ -383,7 +383,7 @@ trait UrlArchiveTrait
                     if (empty($delta->getParams())) {
                         $delta->setParams($this->getParams());
                     }
-                } elseif ('/' !== $path{0}) {
+                } elseif ('/' !== $path[0]) {
                     $path = $this->getPath();
                     if (strpos($path, '/') !== false) {
                         $path = substr($path, 0, strrpos($path, '/'));


### PR DESCRIPTION
Deprecated: Array and string offset access syntax with curly braces is deprecated.