### PR TITLE
add type to getAttribute on DomNodeInterface

### DIFF
--- a/src/Core/Dom/DomNodeInterface.php
+++ b/src/Core/Dom/DomNodeInterface.php
@@ -11,7 +11,7 @@ interface DomNodeInterface
     public function hasClass($className);
     public function hasClasses(array $classNames);
     public function hasAnyClass(array $classNames);
-    public function getAttribute($name);
+    public function getAttribute(string $name);
     public function getTagName();
     public function getNodeValue();
 


### PR DESCRIPTION
missing `string` type was causing an error

PHP definition: https://www.php.net/manual/en/domelement.getattributenode.php
public DOMElement::getAttributeNode ( string $qualifiedName )